### PR TITLE
i18n e l10n dos artefatos LUCI do SIMET na SIMETBox, CURL para GEOAPI; minor fixes

### DIFF
--- a/simetbox-openwrt-base/Makefile
+++ b/simetbox-openwrt-base/Makefile
@@ -29,6 +29,8 @@ PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_REV)
 
+include $(INCLUDE_DIR)/package.mk
+
 # CONFIGURE_ARGS += --with-ssl-dir="$(STAGING_DIR)/usr"
 
 ifeq ($(CONFIG_SIMETBOX_COMMON),y)
@@ -120,8 +122,6 @@ define Package/simetbox-openwrt-base
   URL:=http://simet.nic.br
 #  MENU:=1
 endef
-
-include $(INCLUDE_DIR)/package.mk
 
 define Package/simetbox-openwrt-base/description
  SIMETBox is a suite of tools to measure the quality of the internet. It's designed to be used mainly in Brazil measuring the internet from users home to Internet Exchange Points.

--- a/simetbox-openwrt-base/Makefile
+++ b/simetbox-openwrt-base/Makefile
@@ -116,7 +116,7 @@ define Package/simetbox-openwrt-base
   SECTION:=net
   CATEGORY:=Network
   TITLE:=SIMETBox
-  DEPENDS:=+libjson-c +simetbox-openwrt-config +libopenssl +libpthread +luci-lib-jsonc +luci-lib-json
+  DEPENDS:=+libjson-c +simetbox-openwrt-config +libopenssl +libpthread +luci-lib-jsonc +luci-lib-json +curl +ca-certificates
   URL:=http://simet.nic.br
 #  MENU:=1
 endef

--- a/simetbox-openwrt-luci/Makefile
+++ b/simetbox-openwrt-luci/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014,2015 Hyperboria.net
+# Copyright 2017 NIC.br
 #
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
@@ -18,8 +18,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simetbox-openwrt-luci
 PKG_VERSION:=1.0
-PKG_RELEASE:1
-
+PKG_RELEASE:=1
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+PKG_I18N_DIR:=$(PKG_BUILD_DIR)/luci-i18n
+PKG_BUILD_DEPENDS:=luci-base
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -37,6 +39,7 @@ define Package/simetbox-openwrt-luci/description
 endef
 
 define Build/Compile
+	$(MAKE) -C $(CURDIR)/po PKG_BUILD_DIR=$(PKG_BUILD_DIR) PKG_I18N_DIR=$(PKG_I18N_DIR) i18n-build
 endef
 
 define Package/simetbox-openwrt-luci/install
@@ -44,6 +47,8 @@ define Package/simetbox-openwrt-luci/install
 	$(CP) luasrc/* $(1)/usr/lib/lua/luci
 	$(INSTALL_DIR) $(1)/www
 	$(CP) htdocs/* $(1)/www
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/i18n
+	$(CP) $(PKG_I18N_DIR)/* $(1)/usr/lib/lua/luci/i18n
 endef
 
 $(eval $(call BuildPackage,simetbox-openwrt-luci))

--- a/simetbox-openwrt-luci/luasrc/controller/simet.lua
+++ b/simetbox-openwrt-luci/luasrc/controller/simet.lua
@@ -29,8 +29,8 @@ function index()
 
         node.index = tr
 
-        entry({"admin", "simet", "simet"}, template("simet/simet"), "SIMET Results", 10).dependent=false
-        entry({"admin", "simet", "configuracoes"}, template("simet/configuracoes"), "Settings", 30).dependent=false
+        entry({"admin", "simet", "simet"}, template("simet/simet"), translate("SIMET Results"), 10).dependent=false
+        entry({"admin", "simet", "configuracoes"}, template("simet/configuracoes"), translate("Settings"), 30).dependent=false
 
 
         page = entry({"admin", "simet", "getcrontaboptions"}, call("get_crontab_options"), nil)                                                        

--- a/simetbox-openwrt-luci/po/Makefile
+++ b/simetbox-openwrt-luci/po/Makefile
@@ -1,0 +1,27 @@
+#
+# Copyright 2017 NIC.br
+#
+# You may redistribute this program and/or modify it under the terms of
+# the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This must not be inside any define..endef block,
+# otherwise the bizantine-obfuscator-maximum stuff will
+# will utterly break it by trashing all shell variables
+i18n-build:
+	mkdir -p $(PKG_I18N_DIR)
+	find . -type f -name '*.po' -print | while read -r pofile ; do \
+		pobase=$${pofile%*.po} ; pobase=$${pobase##*/} ; \
+		podir=$${pofile%/*} ; \
+		polang=$${podir##*/} ; \
+		po2lmo $${pofile} $(PKG_I18N_DIR)/$${pobase}.$${polang}.lmo ; \
+	done

--- a/simetbox-openwrt-luci/po/pt-br/simetbox-openwrt-luci.po
+++ b/simetbox-openwrt-luci/po/pt-br/simetbox-openwrt-luci.po
@@ -1,0 +1,49 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: simetbox-openwrt-luci\n"
+"Report-Msgid-Bugs-To: henrique@nic.br\n"
+"Last-Translator: Henrique de Moraes Holschuh <henrique@nic.br>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "BCP38 Respect Tests"
+msgstr "Testes de Respeito à BCP38"
+
+msgid "Content Provider Test"
+msgstr "Testes de Provedores de Conteúdo"
+
+msgid "DNS Tests"
+msgstr "Testes de DNS"
+
+msgid "Periodicity"
+msgstr "Periodicidade"
+
+msgid "Ping to Gateway Tests"
+msgstr "Teste de PING do gateway"
+
+msgid "Port 25 Management Test"
+msgstr "Testes de Gerência da Porta 25"
+
+msgid "SIMET"
+msgstr "SIMET"
+
+msgid "SIMET Results"
+msgstr "Resultados do SIMET"
+
+msgid "Save"
+msgstr "Grava"
+
+msgid "Settings"
+msgstr "Configurações"
+
+msgid "Successfully saved"
+msgstr "Gravado com sucesso"
+
+msgid "Throughput, Latency, Jitter and Packet Loss"
+msgstr "Vazão, Latência, Jitter, e Perda de Pacotes"
+
+msgid "Top 10 Sites Brazil"
+msgstr "Dez sites mais acessados do Brasil (ALEXA)"

--- a/simetbox-openwrt-luci/po/templates/simetbox-openwrt-luci.pot
+++ b/simetbox-openwrt-luci/po/templates/simetbox-openwrt-luci.pot
@@ -1,0 +1,41 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "BCP38 Respect Tests"
+msgstr ""
+
+msgid "Content Provider Test"
+msgstr ""
+
+msgid "DNS Tests"
+msgstr ""
+
+msgid "Periodicity"
+msgstr ""
+
+msgid "Ping to Gateway Tests"
+msgstr ""
+
+msgid "Port 25 Management Test"
+msgstr ""
+
+msgid "SIMET"
+msgstr ""
+
+msgid "SIMET Results"
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Successfully saved"
+msgstr ""
+
+msgid "Throughput, Latency, Jitter and Packet Loss"
+msgstr ""
+
+msgid "Top 10 Sites Brazil"
+msgstr ""


### PR DESCRIPTION
* Alteração de dependências da feed para habilitar pacotes "curl" e "ca-certificates" automaticamente.  Estas alterações são necessárias para a pull-request simetbox/simetbox-openwrt-base#8.

* i18n parcial do SIMET para LUCi (apenas dos artefatos do LUCi, as páginas de relatório ainda estão "hardcoded" em pt_BR).
* l10n para pt_BR dos artefados LUCi do SIMET (menu do LUCi, página de parâmetros dos testes).

* Correções menores no Makefile do simetbox-openwrt-luci.

* Correções menores no Makefile do simetbox-openwrt-base.