### PR TITLE
Cleanups and sysupgrade support for 32MiB RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,9 @@ O SIMETBox já deixa o sistema configurado para utilizar o servidor desejado. Ca
 
 Arquivo | Descrição
 --------|----------
-/usr/bin/simet_uptime\* \*\* | Se conecta ao servidor que indica disponibilidade
 /etc/ifplugd/ifplugd.action | Ação do ifplugd para registro da mudança de estado das interfaces de rede
-/usr/bin/run\_simet\_uptime* | Chama simet_uptime
 /usr/bin/sendifupdown.sh | Envia alterações de estado da interface
-/etc/init.d/uptime\* | Script para inicialização do simet_uptime
 /etc/hotplug.d/iface/60-ifupdownlog | Chama um ifplugd por interface que sobe
-/usr/bin/aplica_transacao.sh* | Aplica transações remotas
 /etc/config/tr069_server | Endereço do servidor TR-069 (ACS) utilizado
 /etc/config/simet\_installed/simetbox\_network\_and\_config\_installed | Indica se foi instalado o pacote de gerência de disponibilide
 /usr/bin/simet_client \*\* | Cliente para realização de teste de latência, jitter, perda de pacotes e vazão
@@ -164,7 +160,6 @@ Arquivo | Descrição
 /usr/bin/run_simet.sh | Roda um conjunto de testes do SIMET (testes relacionados a resolução 574 da ANATEL)
 /usr/bin/simetbox_register.sh | Registra o SIMETBox e seu HASH único para liberar consulta via WEB
 /etc/uci-defaults/99-simet-cron | Configura crontab para os testes do SIMET
-/usr/lib/lua/simet/json\_to\_uci.lua | Biblioteca LUA com funções para conversão de JSON para UCI
 /usr/lib/lua/simet/crontab_writer.lua | Biblioteca LUA usada para gerar a crontab
 /usr/lib/lua/simet/personal_data.lua | Biblioteca LUA usada para gravar os dados cadastrados pelo usuário (nome, velocidade contratada e outros)
 /etc/config/simet\_installed/simetbox\_base\_installed | Indica que o pacote básico do SIMETBox foi instalado

--- a/simetbox-openwrt-availability-config/Makefile
+++ b/simetbox-openwrt-availability-config/Makefile
@@ -41,7 +41,6 @@ define Package/simetbox-openwrt-availability-config/install
 	$(CP) files/ifplugd.action $(1)/etc/ifplugd
 	$(CP) files/sendifupdown.sh $(1)/usr/bin
 	$(CP) files/60-ifupdownlog $(1)/etc/hotplug.d/iface
-	$(CP) files/aplica_transacao.sh $(1)/usr/bin
 	echo $(CONFIG_SIMETBOX_TR069) >> $(1)/etc/config/tr069_server
 	touch $(1)/etc/config/simet_installed/simetbox_network_and_config_installed
 endef

--- a/simetbox-openwrt-availability-config/files/aplica_transacao.sh
+++ b/simetbox-openwrt-availability-config/files/aplica_transacao.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-lua /usr/lib/lua/simet/json_to_uci.lua $1 $2
-

--- a/simetbox-openwrt-base/Makefile
+++ b/simetbox-openwrt-base/Makefile
@@ -153,7 +153,6 @@ define Package/simetbox-openwrt-base/install
 	$(CP_SIMET_CLIENT) $(PKG_BUILD_DIR)/files/run_simet.sh  $(1)/usr/bin
 	$(CP_SIMET_CLIENT) $(PKG_BUILD_DIR)/files/simetbox_register.sh  $(1)/usr/bin
 	$(CP_SIMET_CLIENT) $(PKG_BUILD_DIR)/files/uci-defaults/99-simet-cron  $(1)/etc/uci-defaults
-	$(CP_SIMET_CLIENT) $(PKG_BUILD_DIR)/files/json_to_uci.lua  $(1)/usr/lib/lua/simet
 	$(CP_SIMET_CLIENT) $(PKG_BUILD_DIR)/files/crontab_writer.lua  $(1)/usr/lib/lua/simet
 	$(CP_SIMET_CLIENT) $(PKG_BUILD_DIR)/files/personal_data.lua  $(1)/usr/lib/lua/simet
 	$(TOUCH_SIMET_CLIENT) $(1)/etc/config/simet_installed/simetbox_base_installed

--- a/simetbox-openwrt-base/files/lib/upgrade/nicbrlowram.sh
+++ b/simetbox-openwrt-base/files/lib/upgrade/nicbrlowram.sh
@@ -1,80 +1,144 @@
 #
 # NIC.br - lowram sysupgrade extensions
-# Try to keep this under 4KiB, remove comments on install if required.
+# Copyright (c) 2018 NIC.br
+# distributed under the same license as OpenWRT sysupgrade
 #
 
-# detect low ram situation and do not do anything when we already have at least
-# 10000 kiB free RAM (i.e. twice the largest NOR flash we care about on 32MiB
-# boxes, since nothing sane has 16MiB NOR FLASH + 32MiB RAM).  Note that most
-# of the cached memory is likely to be tmpfs.
+# Detect low ram situation and do not do anything if it would cause us to
+# misflash, due to partial tarballs, or getting killed by the kernel OOMK.
+# Also detect corrupt config tarballs (using gzip -dc >/dev/null), since
+# sysupgrade could generate one of those during OOM.
 
-# Must be a sysupgrade_pre_upgrade hook, because we need rmmod.
-# besides, if we crash the kernel here, we won't misflash.
-nicbr_lowram_preupgrade() {
-	# do some fast cleanup unless we *really* have lots of RAM
-	if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 40000 ] ; then
+nicbr_no_new_processes() {
+	if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 20000 ] ; then
 		rm -fr /tmp/opkg-lists
 		for i in cron atd xinetd ; do
-			[ -x "/etc/init.d/$i" ] && "/etc/init.d/$i" stop && echo "$0: $i stopped"
+			[ -x "/etc/init.d/$i" ] && "/etc/init.d/$i" stop && \
+				echo "$0: service $i stopped" >&2
+		done
+
+		# nicbr SIMET-specific:
+		SIMET_KILL="run_simet.sh simet_dns_ping_traceroute.sh simet_ping.sh simet_traceroute.sh simetbox_register.sh simet_send_if_traffic.sh simet_client simet_alexa simet_bcp38 simet_dns simet_ntpq simet_porta25 simet_tools simet_ws"
+		for i in 1 2 ; do
+			killall -q -TERM $SIMET_KILL
+			sleep 1
+		done
+		for i in 1 2 ; do
+			killall -q -KILL $SIMET_KILL
+			sleep 1
 		done
 		rm -fr /tmp/simet*
+
+		#FIXME: we want a reboot even if we don't upgrade, because se stopped stuff.
+	fi
+	:
+}
+
+nicbr_reboot(){
+	echo "Upgrade aborted, system firmware and configuration unmodified" >&2
+	echo "Rebooting (system is possibly in a downgraded state)..." >&2
+	unmount -a
+	reboot -f
+	sleep 5
+	echo b 2>/dev/null >/proc/sysrq-trigger
+	# Better to hang here if it refuses to reboot
+	while sleep 1000 ; do : ; done
+	exit 1
+}
+
+# Runs before attempting to create a config image, so early RAM freeing
+# can be done here.  It is a hook abuse, but this way we only run when
+# we are actually trying to update firmware.
+nicbr_lowram_preconf() {
+	if [ "$TEST" -ne 1 ]; then
+		nicbr_no_new_processes
+	fi
+	:
+}
+append sysupgrade_image_check nicbr_lowram_preconf
+
+# Runs before creating the conffile tarball
+# Required because sysupgrade is foolhardy enough to NOT check
+# whether tar actually managed to write the damn tarball or not
+nicbr_lowram_conffile() {
+	if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 1000 ] ; then
+		sync && echo 3 > /proc/sys/vm/drop_caches
+		if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 1000 ] ; then
+			echo "$0: FATAL: MemFree is too low to ensure configuration will be preserved" >&2
+			# because we likely killed stuff, otherwise we could just abort
+			nicbr_reboot
+		fi
+	fi
+	:
+}
+append sysupgrade_init_conffiles nicbr_lowram_conffile
+
+# Cannot run too late  because we need rmmod.  Besides, if we crash the
+# kernel here, we won't misflash.
+#
+# Very annoyingly, most damage is done when you run out of RAM *before*
+# this, while sysupgade is trying to preserve config in a tarball.
+nicbr_lowram_preupgrade() {
+	# ensure conf tarball is sane, if any.  We *really* want to move
+	# this to openwrt itself.
+	if [ "$SAVE_CONFIG" -ne 0 ] ; then
+		if ! gzip -dc "$CONF_TAR" >/dev/null 2>&1 ; then
+			echo "$0: FATAL: $CONF_TAR missing, or has a corrupt gzip container" >&2
+			nicbr_reboot
+			exit 1
+		fi
 	fi
 
-	# Don't slow things down unless low on free RAM...
+	# free up more memory
 	if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 10000 ] ; then
 		# stop other "safe" services that are likely to be found on a SIMETBOX
-		echo -n "$0: MemFree is low, trying to stop services: "
+		echo "$0: MemFree is low, trying to stop services... " >&2
 		for i in uhttpd lighttpd httpd apache \
 			 sysntpd ntpd chronyd \
 			 pptpd unbound dnsmasq named xupnpd \
 			 zabbix_agentd easycwmpd ddns p910nd \
 			 minidlna gpsd collectd ugps \
 			 samba netserver adblock privoxy vsftpd ; do
-			[ -x "/etc/init.d/$i" ] && ( "/etc/init.d/$i" stop ; echo -n "$i " )
+			[ -x "/etc/init.d/$i" ] && \
+				( "/etc/init.d/$i" stop ; echo "$0: service: $i stopped" >&2 )
 		done
-		echo
+
 		sync && echo 3 > /proc/sys/vm/drop_caches
 
 		# Don't do dangerous things unless we are _still_ low on free RAM...
-		if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 10000 ] ; then
-			echo "$0: MemFree is still low: attempting to remove wireless module stack..."
+		if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 8000 ] ; then
+			echo "$0: MemFree is still low: attempting to remove wireless module stack..." >&2
 			# remove IEEE802.11 module stack, frees >1MiB
 			# ar71xx specific, because the generic solution is rather dangerous:
 			# you can't expect every module to safely rmmod (and yes, that's a bug)
 			# this will force-down any involved interfaces
 			for i in ath10k_pci ath10k_core ath9k ath9k_common ath9k_hw ath mac80211 cfg80211 ; do
-				rmmod $i >/dev/null 2>&1 || :
+				rmmod $i >/dev/null 2>&1 && echo "$0: module $i removed" >&2
 			done
 		fi
 
-		#FIXME: if still low, remove USB stack, saves ~0.5MiB
+		#FIXME? if still low, remove USB stack, saves ~0.5MiB
 	fi
 	:
 }
 append sysupgrade_pre_upgrade nicbr_lowram_preupgrade
 
+# Runs after most processes have been killed, but we don't have rmmod here
 nicbr_lowram() {
-	# Free as much as possible in /tmp
-	rm -fr /tmp/luci* /tmp/simet* /tmp/opkg*
-	rm -fr /tmp/log/*
+	# the last stage needs far less RAM to sucessfully complete [on ar71xx]...
+	if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 4000 ] ; then
+		rm -fr /tmp/luci* /tmp/simet* /tmp/opkg*
+		rm -fr /tmp/log/* /tmp/p910*
 
-	sync && echo 3 > /proc/sys/vm/drop_caches
+		sync && echo 3 > /proc/sys/vm/drop_caches
 
-	# If we are still low on ram here, abort.  This is better
-	# than the kernel OOM-killing something during mtd write.
-	if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 10000 ] ; then
-		# Assume we do not have enough free RAM to safely sysupgrade
-		echo "FATAL: MemFree is less than 10000 kB, refusing to attempt a firmware write" >&2
-		echo "Rebooting (system unmodified, upgrade aborted)..."
-		unmount -a
-		reboot -f
-		sleep 5
-		echo b 2>/dev/null >/proc/sysrq-trigger
-		# Better to hang here if it refuses to reboot
-		while sleep 10 ; do : ; done
-		exit 1
+		if [ "$( awk '/MemFree:/ { print $2 }' < /proc/meminfo )" -lt 4000 ] ; then
+			# Assume we do not have enough free RAM to safely sysupgrade
+			echo "$0: FATAL: MemFree is still too low, refusing to attempt a firmware write" >&2
+			nicbr_reboot
+			exit 1
+		fi
 	fi
-
 	:
 }
 


### PR DESCRIPTION
* Remove cruft left behind by mistake when we removed the broken "uptime" component
* Better support for sysupgrade on 32MiB RAM