### PR TITLE
Merge recent improvements

### DIFF
--- a/simetbox-openwrt-base/Makefile
+++ b/simetbox-openwrt-base/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_BRANCH:=branches/master
 
 PKG_NAME:=simetbox-openwrt-base
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1

--- a/simetbox-openwrt-base/Makefile
+++ b/simetbox-openwrt-base/Makefile
@@ -137,6 +137,7 @@ define Package/simetbox-openwrt-base/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_DIR) $(1)/etc/factory_config
 	$(INSTALL_DIR) $(1)/lib/upgrade
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(CP) files/* $(1)/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/simet_tools $(1)/usr/bin/
 	$(LN_SIMET_CLIENT) /usr/bin/simet_tools $(1)/usr/bin/simet_client

--- a/simetbox-openwrt-base/files/lib/upgrade/keep.d/nicbrsimet
+++ b/simetbox-openwrt-base/files/lib/upgrade/keep.d/nicbrsimet
@@ -1,0 +1,1 @@
+/etc/simet/

--- a/simetbox-openwrt-base/files/lib/upgrade/nicbrlowram.sh
+++ b/simetbox-openwrt-base/files/lib/upgrade/nicbrlowram.sh
@@ -33,11 +33,11 @@ nicbr_no_new_processes() {
 		# nicbr SIMET-specific:
 		SIMET_KILL="run_simet.sh simet_dns_ping_traceroute.sh simet_ping.sh simet_traceroute.sh simetbox_register.sh simet_send_if_traffic.sh simet_client simet_alexa simet_bcp38 simet_dns simet_ntpq simet_porta25 simet_tools simet_ws"
 		for i in 1 2 ; do
-			killall -q -TERM $SIMET_KILL
+			killall -q -TERM $SIMET_KILL || true
 			sleep 1
 		done
 		for i in 1 2 ; do
-			killall -q -KILL $SIMET_KILL
+			killall -q -KILL $SIMET_KILL || true
 			sleep 1
 		done
 		rm -fr /tmp/simet*


### PR DESCRIPTION
* Avoid the risk of failing sysupgrade because killall returned non-zero status (paranoia).
* Persist /etc/simet on sysupgrades, future changes will need this as we will move anything non-UCI from /etc/config to /etc/simet.